### PR TITLE
Multiplots

### DIFF
--- a/loadSurveyMonkeyXLS.R
+++ b/loadSurveyMonkeyXLS.R
@@ -78,8 +78,8 @@ loadSurveyMonkeyXLS <- function(fname, idcols = 1:9) {
 
   blockType <- sapply(colNameGroups, function(colNames) {
     if(length(colNames) < 2) return("")
-    if(any(qProps[colNames, "multiBlockItems"])) return("multiBlock")
     if(any(qProps[colNames, "multiMatrixItems"])) return("multiMatrix")
+    if(any(qProps[colNames, "multiBlockItems"])) return("multiBlock")
     if(all(qProps[colNames, "numbers"])) return("numericBlock")
     if(sum(qProps[colNames, "lonely"]) > 1) return("lonelyBlock")
     "block"

--- a/multipleResponsePlot.R
+++ b/multipleResponsePlot.R
@@ -265,25 +265,26 @@ numericBlockPlot <- function(answers, splitBy = NA, pop.estimates = T, dotRatioF
     length(levels(factor(answers$subgroup)))
   ratio <- pmin(1, 1 - (ratio - dotRatioFactor)/(ratio + dotRatioFactor*2))
   #geom_dotplot won't dodge by height, so offsets are added manually 
+  #TODO: figure out the offsets - currently having no effect due to binning
   if(is.na(splitBy)) answers$offset <- 0 else
     answers$offset <- (as.numeric(factor(answers[[splitBy]])) - 
-                         mean(seq_along(unique(answers[[splitBy]]))))/10 
+                         mean(seq_along(unique(answers[[splitBy]]))))/3 
   plt <- ggplot(answers, aes(x = subgroup, y = response + offset)) +
-    geom_dotplot(binaxis = "y", stackdir = "center", 
+    geom_dotplot(binaxis = "y", stackdir = "center", color = NA,
                  dotsize = 1, stackratio = ratio) +
     labs(x = "Item", y = "Response")
   if(pop.estimates) {
     plt <- plt +
         stat_summary(aes(linetype = "Mean and\n95% Confidence Interval"), 
-                     fun.data = summaryFun, size = .75,
-                     position = position_dodge(width = .5),
+                     fun.data = summaryFun, size = 1.5,
+                     position = position_dodge(width = .1),
                      shape = ifelse(is.na(splitBy), 19, 21), 
-                     color = "grey50")  +
+                     color = "grey30", alpha = .8)  +
         scale_linetype_manual(name = "Population Estimates", values = 1)
   }
   if(!is.na(splitBy)) plt <- plt + aes_string(fill = splitBy) + 
-    guides(fill = guide_legend(override.aes = list(linetype = 0)),
-           linetype = guide_legend(override.aes = list(fill = "white")))
+    guides(fill = guide_legend(override.aes = list(linetype = 0, size = 1)),
+           linetype = guide_legend(override.aes = list(fill = "white", alpha = 1)))
   tweakPlotDisplay(answers, plt, xAxisTextField = "subgroup")  
 }
 

--- a/multipleResponsePlot.R
+++ b/multipleResponsePlot.R
@@ -137,11 +137,11 @@ responseBlockPlot <- function(answers, splitBy = NA,
                   max(table(answers$response, answers$subgroup, answers[[splitBy]]))) *
     length(levels(factor(answers$subgroup)))
   ratio <- pmin(1, 1 - (ratio - dotRatioFactor)/(ratio + dotRatioFactor*2))
-  #TODO will this ggplot call work with nominal data? 
-  #Is the as.numeric call necessary for ordinal data? Yes for stat_summary
+  #geom_dotplot won't do dodge by height, so offsets are added manually instead
   if(is.na(splitBy)) answers$offset <- 0 else
-    answers$offset <- (as.numeric(answers[[splitBy]]) - 
-                         mean(seq_along(levels(answers[[splitBy]]))))/10 
+    answers$offset <- (as.numeric(factor(answers[[splitBy]])) - 
+                         mean(seq_along(unique(answers[[splitBy]]))))/10 
+  #TODO will this ggplot call work with nominal data? no
   plt <- ggplot(answers, aes(x = subgroup, y = as.numeric(response) + offset)) +
     geom_dotplot(binaxis = "y", stackdir = "center", binwidth = .1, 
                  dotsize = .9, stackratio = ratio, color = NA) +
@@ -152,11 +152,12 @@ responseBlockPlot <- function(answers, splitBy = NA,
         stat_summary(aes(linetype = "Mean and\n95% Confidence Interval",
                          y = as.numeric(response)), 
                      fun.data = mean_cl_normal, size = 1,
-                     position = position_dodge(width = .5))  +
+                     position = position_dodge(width = .5),
+                     shape = 21, color = "grey40")  +
         scale_linetype_manual(name = "Population Estimates", values = 1)
     #TODO: add population estimates for nominal data
   }
-  if(!is.na(splitBy)) plt <- plt + aes_string(fill = splitBy, color = splitBy)
+  if(!is.na(splitBy)) plt <- plt + aes_string(fill = splitBy)
   tweakPlotDisplay(answers, plt, xAxisTextField = "subgroup")
 }
 

--- a/multipleResponsePlot.R
+++ b/multipleResponsePlot.R
@@ -137,7 +137,7 @@ responseBlockPlot <- function(answers, splitBy = NA,
                   max(table(answers$response, answers$subgroup, answers[[splitBy]]))) *
     length(levels(factor(answers$subgroup)))
   ratio <- pmin(1, 1 - (ratio - dotRatioFactor)/(ratio + dotRatioFactor*2))
-  #geom_dotplot won't do dodge by height, so offsets are added manually instead
+  #geom_dotplot won't dodge by height, so offsets are added manually 
   if(is.na(splitBy)) answers$offset <- 0 else
     answers$offset <- (as.numeric(factor(answers[[splitBy]])) - 
                          mean(seq_along(unique(answers[[splitBy]]))))/10 
@@ -153,15 +153,18 @@ responseBlockPlot <- function(answers, splitBy = NA,
                          y = as.numeric(response)), 
                      fun.data = mean_cl_normal, size = 1,
                      position = position_dodge(width = .5),
-                     shape = 21, color = "grey40")  +
+                     shape = ifelse(is.na(splitBy), 19, 21), 
+                     color = "grey40")  +
         scale_linetype_manual(name = "Population Estimates", values = 1)
     #TODO: add population estimates for nominal data
   }
-  if(!is.na(splitBy)) plt <- plt + aes_string(fill = splitBy)
+  if(!is.na(splitBy)) plt <- plt + aes_string(fill = splitBy) + 
+    guides(fill = guide_legend(override.aes = list(linetype = 0)),
+           linetype = guide_legend(override.aes = list(fill = "white")))
   tweakPlotDisplay(answers, plt, xAxisTextField = "subgroup")
 }
 
-multipleResponseBlockPlot <- function(answers, pop.estimates = T) {
+multipleResponseBlockPlot <- function(answers, splitBy = NA, pop.estimates = T) {
   plt <- ggplot(convertResponsesToProportions(answers), 
                 aes(x = response, fill = subgroup, y = prop,
                                        ymax = upr, ymin = lwr)) +


### PR DESCRIPTION
You can now combine the data from multiple SurveyMonkey exports into single plots automatically with explorePlots. For example, if you administered a pre and post test survey, just import both files with loadSurveyMonkeyXLS and then pass both data frames to explorePlots. The questions will be matched between the two surveys by title (and by order for duplicated titles) and appropriate plots will be produced to portray differences between the two survey time points. 
